### PR TITLE
字元字串與進位更新

### DIFF
--- a/BigNumber.h
+++ b/BigNumber.h
@@ -25,6 +25,10 @@ static_assert(BASIC_SIZE >= 2, "BASIC_SIZE should >= 2.");
 typedef long long int BtoI;
 bool string_overflow = false;
 
+const string cvt_string(const string& str);
+template <typename T>
+const string cvt_string(const basic_string<T>& STR);
+
 class BigNumber;
 class BigBigNumber;
 
@@ -54,14 +58,29 @@ private:
 	const BigNumber& PURE_PSEUDOMULTIPLE_assignment();
 	const BigNumber& PURE_PSEUDODIVIDE_assignment();
 	void COMMON_DIVIDE(const BigNumber& n) const;
+	template <typename T>
+	void WIDE_CHAR_PASS(const T& ch);
+	template <typename T>
+	void WIDE_CHARARRAY_PASS(const T* C_STR);
 public:
 	friend ostream& operator << (ostream& os, const BigNumber& n);
 	friend istream& operator >> (istream& is, BigNumber& n);
 	BigNumber();
 	BigNumber(const string& str);
+	template <typename T>
+	BigNumber(const basic_string<T>& STR);
 	BigNumber(const char& ch);
 	BigNumber(char* const n);
 	BigNumber(const char* const n);
+	BigNumber(const wchar_t& ch);
+	BigNumber(wchar_t* const n);
+	BigNumber(const wchar_t* const n);
+	BigNumber(const char16_t& ch);
+	BigNumber(char16_t* const n);
+	BigNumber(const char16_t* const n);
+	BigNumber(const char32_t& ch);
+	BigNumber(char32_t* const n);
+	BigNumber(const char32_t* const n);
 	template <typename T>
 	BigNumber(const T& n);
 	BigNumber(const BigNumber& n);
@@ -90,11 +109,24 @@ public:
 	const BigNumber operator - () const;
 	const BigNumber& operator = (const BigNumber& n);
 	const BigNumber& operator = (const string& str);
+	template <typename T>
+	const BigNumber& operator = (const basic_string<T>& STR);
 	const BigNumber& operator = (const char& ch);
 	const BigNumber& operator = (char* const n);
 	const BigNumber& operator = (const char* const n);
+	const BigNumber& operator = (const wchar_t& ch);
+	const BigNumber& operator = (wchar_t* const n);
+	const BigNumber& operator = (const wchar_t* const n);
+	const BigNumber& operator = (const char16_t& ch);
+	const BigNumber& operator = (char16_t* const n);
+	const BigNumber& operator = (const char16_t* const n);
+	const BigNumber& operator = (const char32_t& ch);
+	const BigNumber& operator = (char32_t* const n);
+	const BigNumber& operator = (const char32_t* const n);
 	template <typename T>
 	const BigNumber& operator = (const T& n);
+	template <typename T>
+	const BigNumber& operator = (T* const n);
 	const BigNumber abs() const;
 	const BigNumber& operator += (const BigNumber& n);
 	template <typename T>
@@ -254,10 +286,8 @@ void BigNumber::PASS_BY_STRING(string str){
 	}
 	if(str.length() > 0 && str[0] == '-'){
 		positive = false;
-		str.erase(0, 1);
 	}else if(str.length() > 0 && str[0] == '+'){
 		positive = true;
-		str.erase(0, 1);
 	}else{
 		positive = true;
 	}
@@ -424,6 +454,17 @@ const BigNumber& BigNumber::PURE_PSEUDODIVIDE_assignment(){ //pseudodivide
 	(*this) = temp;
 	return (*this);
 }
+template <typename T>
+void BigNumber::WIDE_CHAR_PASS(const T& ch){
+	basic_string<T> STR;
+	STR += ch;
+	PASS_BY_STRING(cvt_string(STR));
+}
+template <typename T>
+void BigNumber::WIDE_CHARARRAY_PASS(const T* C_STR){
+	basic_string<T> STR = C_STR;
+	PASS_BY_STRING(cvt_string(STR));
+}
 BigNumber::BigNumber(){
 
 	#ifdef _BIG_NUMBER_DYNAMIC_
@@ -444,6 +485,15 @@ BigNumber::BigNumber(const string& str){
 	#endif
 	(*this) = str;
 }
+template <typename T>
+BigNumber::BigNumber(const basic_string<T>& STR){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = STR;
+}
 BigNumber::BigNumber(const char& ch){
 
 	#ifdef _BIG_NUMBER_DYNAMIC_
@@ -461,6 +511,78 @@ BigNumber::BigNumber(char* const n){
 	(*this) = n;
 }
 BigNumber::BigNumber(const char* const n){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = n;
+}
+BigNumber::BigNumber(const wchar_t& ch){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = ch;
+}
+BigNumber::BigNumber(wchar_t* const n){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = n;
+}
+BigNumber::BigNumber(const wchar_t* const n){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = n;
+}
+BigNumber::BigNumber(const char16_t& ch){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = ch;
+}
+BigNumber::BigNumber(char16_t* const n){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = n;
+}
+BigNumber::BigNumber(const char16_t* const n){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = n;
+}
+BigNumber::BigNumber(const char32_t& ch){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = ch;
+}
+BigNumber::BigNumber(char32_t* const n){
+
+	#ifdef _BIG_NUMBER_DYNAMIC_
+	a = nullptr;
+
+	#endif
+	(*this) = n;
+}
+BigNumber::BigNumber(const char32_t* const n){
 
 	#ifdef _BIG_NUMBER_DYNAMIC_
 	a = nullptr;
@@ -694,6 +816,10 @@ const BigNumber& BigNumber::operator = (const BigNumber& n){
 const BigNumber& BigNumber::operator = (const string& str){
 	PASS_BY_STRING(str);
 }
+template <typename T>
+const BigNumber& BigNumber::operator = (const basic_string<T>& STR){
+	PASS_BY_STRING(cvt_string(STR));
+}
 const BigNumber& BigNumber::operator = (const char& ch){
 	string str;
 	str += ch;
@@ -706,6 +832,33 @@ const BigNumber& BigNumber::operator = (char* const n){
 const BigNumber& BigNumber::operator = (const char* const n){
 	string str = n;
 	PASS_BY_STRING(str);
+}
+const BigNumber& BigNumber::operator = (const wchar_t& ch){
+	WIDE_CHAR_PASS(ch);
+}
+const BigNumber& BigNumber::operator = (wchar_t* const n){
+	WIDE_CHARARRAY_PASS(n);
+}
+const BigNumber& BigNumber::operator = (const wchar_t* const n){
+	WIDE_CHARARRAY_PASS(n);
+}
+const BigNumber& BigNumber::operator = (const char16_t& ch){
+	WIDE_CHAR_PASS(ch);
+}
+const BigNumber& BigNumber::operator = (char16_t* const n){
+	WIDE_CHARARRAY_PASS(n);
+}
+const BigNumber& BigNumber::operator = (const char16_t* const n){
+	WIDE_CHARARRAY_PASS(n);
+}
+const BigNumber& BigNumber::operator = (const char32_t& ch){
+	WIDE_CHAR_PASS(ch);
+}
+const BigNumber& BigNumber::operator = (char32_t* const n){
+	WIDE_CHARARRAY_PASS(n);
+}
+const BigNumber& BigNumber::operator = (const char32_t* const n){
+	WIDE_CHARARRAY_PASS(n);
 }
 template <typename T>
 const BigNumber& BigNumber::operator = (const T& n){
@@ -740,6 +893,12 @@ const BigNumber& BigNumber::operator = (const T& n){
 		string str = ss.str();
 		PASS_BY_STRING(str);
 	}
+	return (*this);
+}
+template <typename T>
+const BigNumber& BigNumber::operator = (T* const n){
+	long long int temp = reinterpret_cast<long long int>(n);
+	(*this) = temp;
 	return (*this);
 }
 const BigNumber BigNumber::abs() const{
@@ -1515,11 +1674,11 @@ const string convert_to_utf8(const basic_string<T>& STR){ //precondition: T is w
 	return str;
 }
 
-const string to_string(const string& str){
+const string cvt_string(const string& str){
 	return str;
 }
 template <typename T>
-const string to_string(const basic_string<T>& STR){
+const string cvt_string(const basic_string<T>& STR){
 	return convert_to_utf8(STR);
 }
 

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -308,11 +308,12 @@ void BigNumber::PASS_BY_STRING(string str){
 }
 void BigNumber::PASS_BY_STRING_with_notation(string str){
 	string_overflow = false;
+	bool remain_positive = false;
 	if(str[0] == '+'){
-		positive = true;
+		remain_positive = true;
 		str.erase(0, 1);
 	}else if(str[0] == '-'){
-		positive = false;
+		remain_positive = false;
 		str.erase(0, 1);
 	}
 	str.erase(0, 1);
@@ -342,6 +343,7 @@ void BigNumber::PASS_BY_STRING_with_notation(string str){
 			return;
 		}
 	}
+	positive = remain_positive;
 }
 const BigNumber& BigNumber::PURE_ADD_assignment(const BigNumber& n){
 

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -1272,19 +1272,25 @@ const T& operator /= (T& n, const BigNumber& N){
 	}
 	return n;
 }
-template <typename T>
-const T operator / (const T& n, const BigNumber& N){ //special, for floating point
-	T temp = n;
-	if(is_floating_point<T>::value){
-		temp /= static_cast<long double>(N);
-	}else{
-		if(is_signed<T>::value){
-			temp /= static_cast<long long int>(N);
-		}else{
-			temp /= static_cast<unsigned long long int>(N);
-		}
-	}
+const float operator / (const float& n, const BigNumber& N){ //special, for floating point
+	float temp = n;
+	temp /= static_cast<long double>(N);
 	return temp;
+}
+const double operator / (const double& n, const BigNumber& N){ //special, for floating point
+	double temp = n;
+	temp /= static_cast<long double>(N);
+	return temp;
+}
+const long double operator / (const long double& n, const BigNumber& N){ //special, for floating point
+	long double temp = n;
+	temp /= static_cast<long double>(N);
+	return temp;
+}
+template <typename T>
+const BigNumber operator / (const T& n, const BigNumber& N){
+	BigNumber temp = n;
+	return temp / N;
 }
 template <typename T>
 const T& operator %= (T& n, const BigNumber& N){

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -1464,7 +1464,7 @@ const string BigNumber::str(int notation = 10) const{
 	ss << note;
 	string temp;
 	BigNumber n = abs();
-	while(n != 0){
+	do{
 		BtoI t = n % notation;
 		if(t < 10){
 			temp += static_cast<char>('0' + t);
@@ -1472,7 +1472,7 @@ const string BigNumber::str(int notation = 10) const{
 			temp += static_cast<char>('A' + (t - 10));
 		}
 		n /= notation;
-	}
+	}while(n != 0);
 	for(int i = temp.length() - 1;i >= 0;i--){
 		ss << temp[i];
 	}

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -1400,17 +1400,20 @@ const string& operator += (string& str, const BigNumber& n){
 	str += ss.str();
 	return str;
 }
-const string operator + (const string& str, const BigNumber& n){
-	stringstream ss;
-	ss << str << n;
-	return ss.str();
-}
-const string operator "" _s(const char* literal_string){ //C++14 has ""s to use.
+const string operator "" _s(const char* literal_string){
 	string str = literal_string;
+	return str;
+}
+const string operator "" _s(const char* string_values, size_t num_chars){ //C++14 has ""s to use.
+	string str = string_values;
 	return str;
 }
 const BigNumber operator "" _b(const char* literal_string){
 	BigNumber temp = literal_string;
+	return temp;
+}
+const BigNumber operator "" _b(const char* string_values, size_t num_chars){
+	BigNumber temp = string_values;
 	return temp;
 }
 

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -308,7 +308,7 @@ void BigNumber::PASS_BY_STRING(string str){
 }
 void BigNumber::PASS_BY_STRING_with_notation(string str){
 	string_overflow = false;
-	bool remain_positive = false;
+	bool remain_positive = true;
 	if(str[0] == '+'){
 		remain_positive = true;
 		str.erase(0, 1);
@@ -338,7 +338,13 @@ void BigNumber::PASS_BY_STRING_with_notation(string str){
 		a[i] = 0;
 	}
 	for(int i = 0;i < str.length();i++){
-		(*this) = static_cast<BigNumber>(str[i]) + ((*this) * notation);
+		BigNumber num;
+		if(isdigit(str[i])){
+			num = str[i];
+		}else{
+			num = static_cast<BtoI>(str[i] - 'A' + 10);
+		}
+		(*this) = num + ((*this) * notation);
 		if(string_overflow){
 			return;
 		}
@@ -436,7 +442,6 @@ BigNumber::BigNumber(const string& str){
 	a = nullptr;
 
 	#endif
-	PASS_BY_STRING(str);
 	(*this) = str;
 }
 BigNumber::BigNumber(const char& ch){

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -66,21 +66,6 @@ public:
 	friend ostream& operator << (ostream& os, const BigNumber& n);
 	friend istream& operator >> (istream& is, BigNumber& n);
 	BigNumber();
-	BigNumber(const string& str);
-	template <typename T>
-	BigNumber(const basic_string<T>& STR);
-	BigNumber(const char& ch);
-	BigNumber(char* const n);
-	BigNumber(const char* const n);
-	BigNumber(const wchar_t& ch);
-	BigNumber(wchar_t* const n);
-	BigNumber(const wchar_t* const n);
-	BigNumber(const char16_t& ch);
-	BigNumber(char16_t* const n);
-	BigNumber(const char16_t* const n);
-	BigNumber(const char32_t& ch);
-	BigNumber(char32_t* const n);
-	BigNumber(const char32_t* const n);
 	template <typename T>
 	BigNumber(const T& n);
 	BigNumber(const BigNumber& n);
@@ -477,125 +462,11 @@ BigNumber::BigNumber(){
 		a[i] = 0;
 	}
 }
-BigNumber::BigNumber(const string& str){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = str;
-}
-template <typename T>
-BigNumber::BigNumber(const basic_string<T>& STR){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = STR;
-}
-BigNumber::BigNumber(const char& ch){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = ch;
-}
-BigNumber::BigNumber(char* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const char* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const wchar_t& ch){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = ch;
-}
-BigNumber::BigNumber(wchar_t* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const wchar_t* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const char16_t& ch){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = ch;
-}
-BigNumber::BigNumber(char16_t* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const char16_t* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const char32_t& ch){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = ch;
-}
-BigNumber::BigNumber(char32_t* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
-BigNumber::BigNumber(const char32_t* const n){
-
-	#ifdef _BIG_NUMBER_DYNAMIC_
-	a = nullptr;
-
-	#endif
-	(*this) = n;
-}
 template <typename T>
 BigNumber::BigNumber(const T& n){
 
 	#ifdef _BIG_NUMBER_DYNAMIC_
-	size = SIZE;
-	a = new int[SIZE];
+	a = nullptr;
 
 	#endif
 	(*this) = n;
@@ -864,7 +735,9 @@ template <typename T>
 const BigNumber& BigNumber::operator = (const T& n){
 
 	#ifdef _BIG_NUMBER_DYNAMIC_
-	resize();
+	size = SIZE;
+	delete[] a;
+	a = new int[SIZE];
 
 	#endif
 	if(is_scalar<T>::value){ //faster

--- a/BigNumber.h
+++ b/BigNumber.h
@@ -1596,6 +1596,11 @@ const string& operator += (string& str, const BigNumber& n){
 	str += ss.str();
 	return str;
 }
+const string operator "" _s(const char literal){
+	string str;
+	str += literal;
+	return str;
+}
 const string operator "" _s(const char* literal_string){
 	string str = literal_string;
 	return str;
@@ -1604,11 +1609,66 @@ const string operator "" _s(const char* string_values, size_t num_chars){ //C++1
 	string str = string_values;
 	return str;
 }
+const string operator "" _s(const wchar_t literal){
+	wstring STR;
+	STR += literal;
+	return cvt_string(STR);
+}
+const string operator "" _s(const wchar_t* string_values, size_t num_chars){ //C++14 has ""s to use.
+	wstring STR = string_values;
+	return cvt_string(STR);
+}
+const string operator "" _s(const char16_t literal){
+	u16string STR;
+	STR += literal;
+	return cvt_string(STR);
+}
+const string operator "" _s(const char16_t* string_values, size_t num_chars){ //C++14 has ""s to use.
+	u16string STR = string_values;
+	return cvt_string(STR);
+}
+const string operator "" _s(const char32_t literal){
+	u32string STR;
+	STR += literal;
+	return cvt_string(STR);
+}
+const string operator "" _s(const char32_t* string_values, size_t num_chars){ //C++14 has ""s to use.
+	u32string STR = string_values;
+	return cvt_string(STR);
+}
+const BigNumber operator "" _b(const char literal){
+	BigNumber temp = literal;
+	return temp;
+}
 const BigNumber operator "" _b(const char* literal_string){
 	BigNumber temp = literal_string;
 	return temp;
 }
 const BigNumber operator "" _b(const char* string_values, size_t num_chars){
+	BigNumber temp = string_values;
+	return temp;
+}
+const BigNumber operator "" _b(const wchar_t literal){
+	BigNumber temp = literal;
+	return temp;
+}
+const BigNumber operator "" _b(const wchar_t* string_values, size_t num_chars){
+	BigNumber temp = string_values;
+	return temp;
+}
+const BigNumber operator "" _b(const char16_t literal){
+	BigNumber temp = literal;
+	return temp;
+}
+const BigNumber operator "" _b(const char16_t* string_values, size_t num_chars){
+	BigNumber temp = string_values;
+	return temp;
+}
+const BigNumber operator "" _b(const char32_t literal){
+	BigNumber temp = literal;
+	return temp;
+}
+const BigNumber operator "" _b(const char32_t* string_values, size_t num_chars){
 	BigNumber temp = string_values;
 	return temp;
 }


### PR DESCRIPTION
我們都知道，編譯器本身無法處理很大的數字，雖然給了很大的數字，但是編譯器會報錯嗎？不用擔心，這次更新添加了用字元字串直接進行指派與算術運算的機能，並且增加字尾_s _b（必須小寫）用於沒有用引號包起來的常數，_s轉為string而_b轉為大數
並且增加進位表示，用成員函數str(n)，n為2-16，就可以用進位的方式輸出；而同時上述的字串也可以用進位制表示（不指定參數則為10進制，而結果會如正常輸出）
用法：輸入的字串格式：（可選，一個+或-）0" "後面接上一串數字或字母（大小不拘），其中" "為一個大小皆可之英文字母，若是2-15進位則為對應順序的英文字母，2為b而8為h。16進位為x。後面的一串數字或字母則可為任意數字與字母，就算超過進位制合法的顯示範圍亦可。比如輸入2進位時輸入0bf77亦可轉譯。